### PR TITLE
Add Restart to Unfinished Batch Processing Actions

### DIFF
--- a/views/batch-manage.php
+++ b/views/batch-manage.php
@@ -29,7 +29,8 @@ $percentage = $batch->get_percentage();
 	<div class="batch-process-actions">
 		<?php if(!$batch->is_finished()): ?>
 			<button class="button-primary" id="batch-process-start">Start</button>
-			<button class="button" id="batch-process-stop">Stop</button>
+			<button class="button" id="batch-process-restart">Restart</button>
+			<button class="button batch-process--button-stop" id="batch-process-stop">Stop</button>
 		<?php else: ?>
 			<button class="button-primary" id="batch-process-restart">Restart</button>
 		<?php endif; ?>
@@ -86,5 +87,10 @@ $percentage = $batch->get_percentage();
     padding-bottom: 5px;
     min-height: 12px;
 }
-
+.batch-process--button-stop {
+    margin-left: 15px !important;
+    border: none !important;
+    background: #990000 !important;
+    color: #ffffff !important;
+}
 </style>


### PR DESCRIPTION
This PR is in reference to this comment here: https://github.com/gdarko/wp-batch-processing/issues/16

I agree, a Restart option would be nice for longer batches in the event you make a code change to how a batch is processed and want to run the processing code against the entire batch from scratch, without waiting for the in-progress batch to complete.

I wasn't sure about how the buttons should display, so I added a new class for the Stop button styling specifically.