### PR TITLE
Fixing PHP 8 warnings

### DIFF
--- a/includes/class-bp-singleton.php
+++ b/includes/class-bp-singleton.php
@@ -48,9 +48,9 @@ trait WP_BP_Singleton {
 	protected function init() {
 	}
 
-	final private function __wakeup() {
+	public function __wakeup() {
 	}
 
-	final private function __clone() {
+	private function __clone() {
 	}
 }


### PR DESCRIPTION
Running PHP 8.0, in the WordPress admin area (specifically `/wp-admin/admin.php?page=dg-batches`) I'm getting the following warnings:

> Warning: Private methods cannot be final as they are never overridden by other classes in /var/www/html/wp-content/plugins/wp-batch-processing/includes/class-bp-singleton.php on line 51
>
> Warning: The magic method WP_BP_Singleton::__wakeup() must have public visibility in /var/www/html/wp-content/plugins/wp-batch-processing/includes/class-bp-singleton.php on line 51
>
> Warning: Private methods cannot be final as they are never overridden by other classes in /var/www/html/wp-content/plugins/wp-batch-processing/includes/class-bp-singleton.php on line 54

References:
* https://php.watch/versions/8.0/final-private-function
* https://stackoverflow.com/questions/8231090/why-do-php-magical-methods-have-to-be-public (Couldn't find a better link than SO). 

PR addresses the warnings. 

Thanks!