### PR TITLE
Add WP CLI command (Update)

### DIFF
--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 /**
  * Class Batch_Processor_CLI_Command().
  */
-class Batch_Processor_CLI_Command extends WP_CLI_Command {
+class WP_Batch_Processor_CLI_Command extends WP_CLI_Command {
 
 	/**
 	 * Process a registered batch by ID.

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -1,0 +1,55 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	die('Direct access is not allowed.');
+}
+
+/**
+ * Class Batch_Processor_CLI_Command().
+ */
+class Batch_Processor_CLI_Command extends WP_CLI_Command {
+
+	/**
+	 * Process a registered batch by ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <batch-id>
+	 * : The unique ID of the batch to run.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp batch_process email_post_authors
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		list( $batch_id ) = $args;
+		do_action( 'wp_batch_processing_init' );
+
+		$batch = WP_Batch_Processor::get_instance()->get_batch($batch_id);
+		if ( !$batch ) {
+			WP_CLI::error( "Batch with ID '{$batch_id}' not found." );
+			return;
+		}
+
+		WP_CLI::log( "Starting processing batch: {$batch_id} with {$batch->get_items_count()} items" );
+
+		$batch_items = $batch->get_all_items();
+		$progress = WP_CLI\Utils\make_progress_bar( "Processing batch items", $batch->get_items_count() );
+
+		/** @var WP_Batch_Item $item */
+		foreach ( $batch_items as $item ) {
+			// Process each item in the batch.
+			try {
+				if ( !$batch->is_processed( $item ) ) {
+					$batch->process( $item );
+					$batch->mark_as_processed( $item->id );
+				}
+			} catch ( Exception $e ) {
+				WP_CLI::warning( "Error processing item ID {$item->id}: " . $e->getMessage() );
+			}
+			$progress->tick();
+		}
+
+		WP_CLI::success( "Batch '{$batch_id}' processing complete." );
+	}
+}

--- a/wp-batch-processing.php
+++ b/wp-batch-processing.php
@@ -26,7 +26,7 @@ require_once 'includes/class-batch-processor-admin.php';
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once 'includes/class-wp-cli.php';
 
-	$wp_cli_command = new Batch_Processor_CLI_Command();
+	$wp_cli_command = new WP_Batch_Processor_CLI_Command();
 	WP_CLI::add_command( 'batch_process', $wp_cli_command );
 }
 
@@ -46,3 +46,4 @@ WP_Batch_Processor::boot();
 
 // Examples
 // require_once 'examples/class-example-batch.php';
+

--- a/wp-batch-processing.php
+++ b/wp-batch-processing.php
@@ -14,6 +14,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
+require_once 'includes/class-bp-helper.php';
+require_once 'includes/class-bp-singleton.php';
+require_once 'includes/class-batch-item.php';
+require_once 'includes/class-batch.php';
+require_once 'includes/class-batch-processor.php';
+require_once 'includes/class-batch-ajax-handler.php';
+require_once 'includes/class-batch-list-table.php';
+require_once 'includes/class-batch-processor-admin.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once 'includes/class-wp-cli.php';
+
+	$wp_cli_command = new Batch_Processor_CLI_Command();
+	WP_CLI::add_command( 'batch_process', $wp_cli_command );
+}
+
 if ( ! is_admin() ) {
 	return;
 }
@@ -25,15 +41,6 @@ if ( ! defined( 'WP_BP_PATH' ) ) {
 if ( ! defined( 'WP_BP_URL' ) ) {
 	define( 'WP_BP_URL', plugin_dir_url( __FILE__ ) );
 }
-
-require_once 'includes/class-bp-helper.php';
-require_once 'includes/class-bp-singleton.php';
-require_once 'includes/class-batch-item.php';
-require_once 'includes/class-batch.php';
-require_once 'includes/class-batch-processor.php';
-require_once 'includes/class-batch-ajax-handler.php';
-require_once 'includes/class-batch-list-table.php';
-require_once 'includes/class-batch-processor-admin.php';
 
 WP_Batch_Processor::boot();
 


### PR DESCRIPTION
Sorry for the new PR, I couldn't contribute to the original PR and wanted to contribute in a way that provided a mergeable update. 

---

I've taken a look at BramDriesen's work in https://github.com/gdarko/wp-batch-processing/pull/24 but ran in to a couple of issues. 

1. Renamed the command for consistency with core ([commit](https://github.com/gdarko/wp-batch-processing/commit/699be973d4c10e125d0f1ed5fdebf4abeeef5ab9))

`wp batch-processing {enter_your_batch_id}`

2. Function `get_all_items()` doesn't seem to exist in `/includes/class-batch.php`. I have made `$items` public and adjusted `class-wp-cli.php` accordingly. ([commit](https://github.com/gdarko/wp-batch-processing/commit/bf5b1ae317a5c83dc871c29276f6e95692c6d286))

I've opted for making `$items` public instead of adding the missing `get_all_items()` function, I wasn't sure if this was missing from the original PR or was removed from the main plugin at some point. Making the property public seemed to be a low risk option with minimal code changes. 

--- 

I believe this PR is mergeable, but having used it some QoL additions would be to include a command to: 
1. List available batches
2. Restart a batch